### PR TITLE
change link location from local host to heroku

### DIFF
--- a/public/js/review.js
+++ b/public/js/review.js
@@ -72,7 +72,7 @@ $(document).ready(function () {
           const newID = window.location.search.substring(7);
           for (let i = 0; i < dataList.length; i++) {
             if (dataList[i].alias === newID) {
-              const newURL = `http://localhost:3000/business${window.location.search}`
+              const newURL = `https://yelpper.herokuapp.com/business${window.location.search}`
               $(".thank-you-header").html(`${dataList[i].name}`)
               $(".see-review").attr("href", newURL)
             }


### PR DESCRIPTION
This is a post-graded fix, where I change a link from localhost  to the  correct heroku link.